### PR TITLE
Provide Colorable Trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::ptr::NonNull;
 
+/// NodeRef represents a Non-Null pointer to a Node.
 type NodeRef<V> = NonNull<Node<V>>;
 
 /// Represents a type that has a Color representation in the tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,14 @@ use std::ptr::NonNull;
 
 type NodeRef<V> = NonNull<Node<V>>;
 
-/// Represents a type that can be painted either Red or Black for tree
-/// balancing purposes.
+/// Represents a type that has a Color representation in the tree.
 trait Colored {
     /// Returns the color of a specific item.
     fn color(&self) -> Color;
+}
+
+/// A subtype of the `Colored` trait that allows for mutation of its color
+trait ColoredMut: Colored {
     /// Sets the color of an object to a passed color.
     fn set_color_mut(&mut self, color: Color);
     /// Inverts the color of a node.
@@ -19,7 +22,9 @@ impl<V> Colored for NodeRef<V> {
         let node = unsafe { self.as_ref() };
         node.color
     }
+}
 
+impl<V> ColoredMut for NodeRef<V> {
     fn set_color_mut(&mut self, color: Color) {
         let mut node = unsafe { self.as_mut() };
         node.color = color;
@@ -39,7 +44,9 @@ impl<V> Colored for Option<NodeRef<V>> {
             None => Color::Black,
         }
     }
+}
 
+impl<V> ColoredMut for Option<NodeRef<V>> {
     fn set_color_mut(&mut self, color: Color) {
         if let Some(mut noderef) = self {
             noderef.set_color_mut(color)
@@ -174,7 +181,9 @@ impl<V> Colored for Node<V> {
     fn color(&self) -> Color {
         self.color
     }
+}
 
+impl<V> ColoredMut for Node<V> {
     fn set_color_mut(&mut self, color: Color) {
         self.color = color;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@ use std::ptr::NonNull;
 type NodeRef<V> = NonNull<Node<V>>;
 
 /// Represents a type that has a Color representation in the tree.
-trait Colored {
+trait Colorable {
     /// Returns the color of a specific item.
     fn color(&self) -> Color;
 }
 
 /// A subtype of the `Colored` trait that allows for mutation of its color
-trait ColoredMut: Colored {
+trait ColorableMut: Colorable {
     /// Sets the color of an object to a passed color.
     fn set_color_mut(&mut self, color: Color);
     /// Inverts the color of a node.
@@ -17,14 +17,14 @@ trait ColoredMut: Colored {
     fn set_flip_mut(&mut self);
 }
 
-impl<V> Colored for NodeRef<V> {
+impl<V> Colorable for NodeRef<V> {
     fn color(&self) -> Color {
         let node = unsafe { self.as_ref() };
         node.color
     }
 }
 
-impl<V> ColoredMut for NodeRef<V> {
+impl<V> ColorableMut for NodeRef<V> {
     fn set_color_mut(&mut self, color: Color) {
         let mut node = unsafe { self.as_mut() };
         node.color = color;
@@ -37,7 +37,7 @@ impl<V> ColoredMut for NodeRef<V> {
     }
 }
 
-impl<V> Colored for Option<NodeRef<V>> {
+impl<V> Colorable for Option<NodeRef<V>> {
     fn color(&self) -> Color {
         match self {
             Some(noderef) => noderef.color(),
@@ -46,7 +46,7 @@ impl<V> Colored for Option<NodeRef<V>> {
     }
 }
 
-impl<V> ColoredMut for Option<NodeRef<V>> {
+impl<V> ColorableMut for Option<NodeRef<V>> {
     fn set_color_mut(&mut self, color: Color) {
         if let Some(mut noderef) = self {
             noderef.set_color_mut(color)
@@ -177,13 +177,13 @@ where
     }
 }
 
-impl<V> Colored for Node<V> {
+impl<V> Colorable for Node<V> {
     fn color(&self) -> Color {
         self.color
     }
 }
 
-impl<V> ColoredMut for Node<V> {
+impl<V> ColorableMut for Node<V> {
     fn set_color_mut(&mut self, color: Color) {
         self.color = color;
     }


### PR DESCRIPTION
# Introduction
This PR introduces a `Colorable` trait that defines types that can have color value assigned to them as well as a `ColorableMut` trait that allows modifications of the color of said types.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
