### PR TITLE
Port raw NonNull pointer type to a wrapping NodeRef type.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,11 +216,11 @@ where
         }
     }
 
-    unsafe fn parent(&self) -> Option<NodeRef<T>> {
+    fn parent(&self) -> Option<NodeRef<T>> {
         self.parent
     }
 
-    unsafe fn sibling(&self) -> Option<NodeRef<T>> {
+    fn sibling(&self) -> Option<NodeRef<T>> {
         let direction = self.direction()?;
         let parent = self.parent?;
 
@@ -230,11 +230,11 @@ where
         }
     }
 
-    unsafe fn grandparent(&self) -> Option<NodeRef<T>> {
+    fn grandparent(&self) -> Option<NodeRef<T>> {
         self.parent.and_then(|parent| parent.as_ref().parent)
     }
 
-    unsafe fn uncle(&self) -> Option<NodeRef<T>> {
+    fn uncle(&self) -> Option<NodeRef<T>> {
         self.parent.and_then(|parent| parent.as_ref().sibling())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1212,4 +1212,18 @@ mod tests {
             new_root.and_then(|c| c.as_ref().right)
         );
     }
+
+    #[test]
+    fn should_retain_order_after_deletion() {
+        let tree = (0..1024)
+            .rev()
+            .fold(RedBlackTree::default(), |tree, x| tree.insert(x))
+            .remove(&511)
+            .remove(&512);
+
+        let received: Vec<u16> = tree.traverse_in_order().copied().collect();
+        // skip 511 and 512
+        let expected: Vec<u16> = (0..511).chain(513..1024).collect();
+        assert_eq!(expected, received);
+    }
 }


### PR DESCRIPTION
# Introduction
This PR moves the `NodeRef<T>` type from a type alias over `std::ptr::NonNull<T>` to a newtype wrapper around `std::ptr::NonNull<T>` to simplify the implementation of helper traits on each individual tree node.

# Linked Issues
resolves #12 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
