### PR TITLE
Initial PR to stub benchmarking

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,5 +3,5 @@
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
 # [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends valgrind

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 		"--security-opt",
 		"seccomp=unconfined"
 	],
-
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"lldb.executable": "/usr/bin/lldb",
@@ -20,7 +19,6 @@
 		},
 		"rust-analyzer.checkOnSave.command": "clippy"
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"vadimcn.vscode-lldb",
@@ -29,13 +27,10 @@
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-
+	"postCreateCommand": "cargo install cargo-valgrind",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,28 @@
+name: Bench
+
+on: [push]
+
+jobs:
+  build_and_test:
+    name: Bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: measure benchmarks on main
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+      - uses: actions/checkout@v2
+        with:
+          clean: false
+      - name: measure banchmarks on branch
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+      - name: upload benchmark report
+        uses: actions/upload-artifact@v1
+        with:
+          name: Benchmark report
+          path: target/criterion/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: cargo-valgrind
+          components: rustfmt
+      - name: Install cargo-valgrind
+        run: cargo install cargo-valgrind
       - name: Release build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Stable with rustfmt and clippy
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: cargo-valgrind
       - name: Release build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,11 @@ jobs:
           toolchain: stable
           components: rustfmt
       - name: Install cargo-valgrind
-        run: cargo install cargo-valgrind
-      - name: Release build
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-valgrind
+      - name: Run valgrind against basic example
         uses: actions-rs/cargo@v1
         with:
           command: valgrind

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: rustup component add clippy
+      - name: Stable with rustfmt and clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -19,3 +24,20 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
+  leak_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install valgrind
+        run: sudo apt-get install valgrind
+      - name: Stable with rustfmt and clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: cargo-valgrind
+      - name: Release build
+        uses: actions-rs/cargo@v1
+        with:
+          command: valgrind
+          args: run --example basic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "rbtree"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "ops"
+harness = false
 
 [dependencies]

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -13,7 +13,7 @@ pub fn insertion(c: &mut Criterion) {
                 &sample_size,
                 |b, &s| {
                     b.iter(|| {
-                        let populated_tree = (0..s)
+                        let _populated_tree = (0..s)
                             .fold(RedBlackTree::default(), |tree, x| tree.insert(black_box(x)));
                     })
                 },

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -1,0 +1,25 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rbtree::RedBlackTree;
+
+pub fn insertion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insertion into the tree");
+
+    (0..5)
+        .map(|multiple| 2usize.pow(multiple))
+        .for_each(|sample_size| {
+            group.throughput(Throughput::Elements(sample_size as u64));
+            group.bench_with_input(
+                BenchmarkId::new("insertion into tree with nodes", sample_size),
+                &sample_size,
+                |b, &s| {
+                    b.iter(|| {
+                        let populated_tree = (0..s)
+                            .fold(RedBlackTree::default(), |tree, x| tree.insert(black_box(x)));
+                    })
+                },
+            );
+        })
+}
+
+criterion_group!(benches, insertion);
+criterion_main!(benches);

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -4,7 +4,7 @@ use rbtree::RedBlackTree;
 pub fn insertion(c: &mut Criterion) {
     let mut group = c.benchmark_group("insertion into the tree");
 
-    (0..5)
+    (0..10)
         .map(|multiple| 2usize.pow(multiple))
         .for_each(|sample_size| {
             group.throughput(Throughput::Elements(sample_size as u64));

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,14 @@
+use rbtree::RedBlackTree;
+
+fn main() {
+    let populated_tree = (0..1024).fold(RedBlackTree::default(), |tree, x| tree.insert(x));
+
+    let min = populated_tree.min();
+    let max = populated_tree.max();
+
+    println!(
+        "The min and max of the tree are: {} - {}",
+        min.unwrap(),
+        max.unwrap()
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ impl<T> SearchResult<T> {
 }
 
 /// An implementation of a Red-Black Tree
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RedBlackTree<T>
 where
     T: PartialEq + PartialOrd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,7 @@ where
             }
             SearchResult::Miss(mut parent_node) => {
                 let is_left = value < parent_node.as_ref().inner;
-                let child = Box::new(Node::new(Color::Red, value, Some(parent_node), None, None));
+                let child = Node::new(Color::Red, value, Some(parent_node), None, None);
                 let child_ptr = NodeRef::from(child);
                 if is_left {
                     parent_node.as_mut().left = Some(child_ptr);
@@ -455,6 +455,9 @@ where
                         Direction::Left => parent.as_mut().left = None,
                         Direction::Right => parent.as_mut().right = None,
                     };
+                } else {
+                    // Mark the tree as empty if this is the last node.
+                    self.root = None;
                 }
 
                 // Take ownership of the inner value
@@ -896,6 +899,7 @@ where
     }
 }
 
+/*
 impl<T> Drop for RedBlackTree<T>
 where
     T: PartialOrd + PartialEq,
@@ -908,7 +912,7 @@ where
                 let min = value;
                 let max = self.max();
                 let is_last_node = Some(min) == max;
-                let node = self.find_nearest_node(min).hit_then(|node| node).unwrap();
+                let node = self.find_nearest_node(value).hit_then(|node| node).unwrap();
                 let direction = node.as_ref().direction();
                 if let Some(mut parent) = node.as_ref().parent {
                     // parent assertion makes unwrap safe
@@ -924,13 +928,34 @@ where
                         Box::from_raw(node_ptr);
                         break;
                     } else {
-                        next = self.max();
+                        next = max;
                         continue;
                     }
                 }
 
                 let node_ptr = node.as_ptr();
                 Box::from_raw(node_ptr);
+                next = self.min();
+            }
+
+            self.root = None;
+        }
+    }
+}
+*/
+
+impl<T> Drop for RedBlackTree<T>
+where
+    T: PartialOrd + PartialEq,
+{
+    fn drop(&mut self) {
+        unsafe {
+            let mut next = self.min();
+            while let Some(value) = next {
+                let node = self.find_nearest_node(value).hit_then(|node| node).unwrap();
+                let inner_val = &node.as_ptr().as_ref().unwrap().inner;
+                self.remove_mut(inner_val);
+
                 next = self.min();
             }
 


### PR DESCRIPTION
# Introduction
This PR stubs benchmarking using criterion, but additional fixes a fairly significant memory leak in the drop code for node pointers.

## Memory Leak
A memory leak was introduced due to the tree incorrectly handling cleanup, and optionally rotation, of the root when it is encountered. This was corrected by:

- Using the built in `remove` methods rather than hand-rolling a drop.
- Explicitly setting the node to `None` if it's the last node removed.
- Introducing a basic test for valgrind validation

## Benchmarks
This PR also sets up the initial stub for benchmark testing and includes an initial test for `insertion`. This is where the initial error was spotted due to segfault as many trees were tested.

# Linked Issues
#16 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
